### PR TITLE
chore: bump GitHub Action pins to latest releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
 
       - name: Install dependencies
         run: npm install
@@ -23,13 +23,13 @@ jobs:
         run: npm run build
 
       - name: Upload production-ready build files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: production-files
           path: ./dist
 
       - name: Upload osmbuildings
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: osmbuildings
           path: ./osmbuildings
@@ -42,7 +42,7 @@ jobs:
     if: github.ref == 'refs/heads/dev'
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: production-files
           path: ./dist
@@ -52,7 +52,7 @@ jobs:
 #        working-directory: ./dist
 
       - name: Download osmbuildings
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: osmbuildings
           path: ./osmbuildings
@@ -70,7 +70,7 @@ jobs:
 #        working-directory: ./dist
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
Bumps pinned versions of several GitHub Actions in `.github/workflows/deploy.yml`:

- `actions/checkout@v4` -> `actions/checkout@v6.0.2`
- `actions/setup-node@v4` -> `actions/setup-node@v6.3.0`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v7.0.0`
- `actions/download-artifact@v4` -> `actions/download-artifact@v8.0.1`
- `peaceiris/actions-gh-pages@v3` -> `peaceiris/actions-gh-pages@v4.0.0`

Please review and test the workflow before merging.

Manual run and testing instructions:

- Go to the repository on GitHub → Actions → select the "Deploy to GitHub Pages" workflow.
- Click "Run workflow", choose the `branch` input (default: `dev`) and run it.
- Verify steps:
  1. `Build` job completes successfully.
  2. `Upload production-ready build files` step creates the `production-files` artifact.
  3. `Download artifact` step in the `Deploy` job successfully downloads `production-files` and `osmbuildings`.
  4. `Deploy to GitHub Pages` step completes without errors and publishes `./dist`.
- If any step fails, check the job logs for changed action inputs (see action changelogs linked below) and adjust the workflow config accordingly.

Helpful links (changelogs / releases):
- actions/checkout: https://github.com/actions/checkout/releases
- actions/setup-node: https://github.com/actions/setup-node/releases
- actions/upload-artifact: https://github.com/actions/upload-artifact/releases
- actions/download-artifact: https://github.com/actions/download-artifact/releases
- peaceiris/actions-gh-pages: https://github.com/peaceiris/actions-gh-pages/releases

If you want, I can also add a brief section here explaining any breaking changes found in the changelogs.